### PR TITLE
Fixed GPU implementation

### DIFF
--- a/src/gtr.py
+++ b/src/gtr.py
@@ -212,7 +212,7 @@ class AddPrecomputedGTREdges(BaseTransform):
                 torch.ones(2*self.num_edges, dtype=torch.long)
             ])
         # add new edges
-        new_edges = data.precomputed_gtr_edges[:,:2*self.num_edges]
+        new_edges = data.precomputed_gtr_edges[:,:2*self.num_edges].to(data.edge_index.device)
         data.edge_index = torch.cat([data.edge_index, new_edges], dim=1)
         return data
 


### PR DESCRIPTION
Hi, when using the GPU, `AddPrecomputedGTREdges` fails because it tries to concatenate a GPU tensor `data.edge_index` with a CPU tensor `new_edges`*. I have amended a line to put `new_edges` on `data.edge_index`'s device.

*`GTREdgeBuilder.compute_edges` always returns a CPU tensor. I don't know if that is intended behavior, so instead of amending the return type of `compute_edges`, I made the change in `AddPrecomputedGTREdges`.